### PR TITLE
Add YouTube to MP3 conversion functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8.5"
+std = { version = "0.1" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,44 @@
 use std::io;
+use std::process::Command;
 
 fn main() {
+    if !is_yt_dlp_installed() {
+        println!("yt-dlp is not installed. Please install it first.");
+        return;
+    }
 
-  println!("Guess the number!");
-  println!("Please input the number!");
+    println!("Enter YouTube URL:");
+    let mut url = String::new();
+    io::stdin()
+        .read_line(&mut url)
+        .expect("Failed to read line");
 
-  let mut guess_number = String::new();
+    match convert_youtube_to_audio(&url.trim()) {
+        Ok(_) => println!("Conversion completed successfully!"),
+        Err(e) => println!("Error during conversion: {}", e),
+    }
+}
 
-  io::stdin()
-    .read_line(&mut guess_number)
-    .expect("Failed to read the lined");
+fn convert_youtube_to_audio(url: &str) -> Result<(), String> {
+    let output = Command::new("yt-dlp")
+        .args([
+            "-x",
+            "--audio-format", "mp3",
+            url,
+        ])
+        .output()
+        .map_err(|e| e.to_string())?;
 
-  println!("Your guess number is {}", guess_number)
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).to_string())
+    }
+}
 
+fn is_yt_dlp_installed() -> bool {
+    Command::new("yt-dlp")
+        .arg("--version")
+        .output()
+        .is_ok()
 }


### PR DESCRIPTION
This PR transforms the application into a YouTube to MP3 converter using the yt-dlp command-line tool. Changes include:

- Replaced number guessing game with YouTube URL input functionality
- Added `convert_youtube_to_audio()` function to handle MP3 conversion
- Added `is_yt_dlp_installed()` function to check for yt-dlp dependency
- Updated dependencies in Cargo.toml
- Added error handling for conversion process

The application now:
1. Checks if yt-dlp is installed
2. Prompts for a YouTube URL
3. Converts the video to MP3 format
4. Provides success/error feedback to the user

**Note:** Requires yt-dlp to be installed on the system to function.