### PR TITLE
Add max profit calculation functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,4 @@
 [package]
-name = "guessing_game"
+name = "rust-day-one"
 version = "0.1.0"
 edition = "2021"
-
-[dependencies]
-rand = "0.8.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,6 @@
-use std::io;
+mod max_profit;
 
 fn main() {
-
-  println!("Guess the number!");
-  println!("Please input the number!");
-
-  let mut guess_number = String::new();
-
-  io::stdin()
-    .read_line(&mut guess_number)
-    .expect("Failed to read the lined");
-
-  println!("Your guess number is {}", guess_number)
-
+    let prices = vec![7,1,5,3,6,4];
+    println!("Maximum profit: {}", max_profit::max_profit(prices));
 }

--- a/src/max_profit.rs
+++ b/src/max_profit.rs
@@ -1,0 +1,23 @@
+pub fn max_profit(prices: Vec<i32>) -> i32 {
+    let mut min_price = i32::MAX;
+    let mut max_profit = 0;
+    
+    for &price in prices.iter() {
+        min_price = min_price.min(price);
+        max_profit = max_profit.max(price - min_price);
+    }
+    
+    max_profit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_profit() {
+        assert_eq!(max_profit(vec![7,1,5,3,6,4]), 5);
+        assert_eq!(max_profit(vec![7,6,4,3,1]), 0);
+        assert_eq!(max_profit(vec![2,4,1]), 2);
+    }
+}


### PR DESCRIPTION
This PR adds functionality to calculate the maximum profit from a list of stock prices. Changes include:

- Created new `max_profit.rs` module with implementation and unit tests
- Updated `main.rs` to use the new max profit functionality
- Updated `Cargo.toml` with new package name and removed unused dependencies

The `max_profit` function finds the maximum profit that can be obtained by buying at a lower price and selling at a higher price later. The implementation uses a single pass through the prices array while tracking the minimum price seen so far and the maximum profit possible.